### PR TITLE
更新库名称及文档以反映新名称和描述

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MyStack.DistributedMessage4RabbitMQ
+# DistributedMessage4RabbitMQ
 
 An open-source lightweight message bus library (RabbitMQ) that supports publish/subscribe and RPC.
 
@@ -6,11 +6,11 @@ An open-source lightweight message bus library (RabbitMQ) that supports publish/
 | ----------- | ----------- | 
 | [![nuget](https://img.shields.io/nuget/v/DistributedMessage4RabbitMQ.svg?style=flat-square)](https://www.nuget.org/packages/DistributedMessage4RabbitMQ)    | [![stats](https://img.shields.io/nuget/dt/DistributedMessage4RabbitMQ.svg?style=flat-square)](https://www.nuget.org/stats/packages/DistributedMessage4RabbitMQ?groupby=Version)         |
 
-# Install MyStack.DistributedMessage4RabbitMQ
+# Install DistributedMessage4RabbitMQ
 
 You can install via NuGet:
 ```csharp
-Install-Package MyStack.DistributedMessage4RabbitMQ
+Install-Package DistributedMessage4RabbitMQ
 
 # Getting Started
 


### PR DESCRIPTION
修改了项目标题为 `DistributedMessage4RabbitMQ`，并添加了对库的简要描述，说明其是一个支持发布/订阅和 RPC 的开源轻量级消息总线库（基于 RabbitMQ）。 更新了 NuGet 徽章的显示和链接，提供最新版本和下载统计信息。
调整了安装说明和“Getting Started”部分的内容以适应新的库名称。